### PR TITLE
fix: markdown图片绝对路径与TFile.path 匹配

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -87,7 +87,7 @@ export default {
       const imgPathMap :Record<string, any> = {};
       for (let ix = 0; ix < imgPathItems.length; ix++) {
         // @TODO: this is a hack, but it works for now
-        const formalizedPathname = decodeURIComponent(imgPathItems[ix]).replace(/^\.\//, '')
+        const formalizedPathname = decodeURIComponent(imgPathItems[ix]).replace(/^(\.\/|\/)/, '');
         imgPathMap[formalizedPathname] = {
           pathname: imgPathItems[ix],
           formalizedPathname,


### PR DESCRIPTION
插件库方法 app.vault.getFiles();  在我的本地环境获取到的路径为 imgs/logo.png 
正则获取到正文的图片绝对路径为 /imgs/logo.png （按照文档指导填写的目录格式，正文中写成 imgs/logo.png 也可解决）

两者不匹配导致无法触发图片上传流程，这里对路径修改的正则 增加以 '/' 开头的情况处理